### PR TITLE
cpu_sub_system_axi: Fix multiple intc drivers

### DIFF
--- a/smart_run/logical/common/cpu_sub_system_axi.v
+++ b/smart_run/logical/common/cpu_sub_system_axi.v
@@ -364,7 +364,7 @@ end
 // assign pad_plic_int_vld  = {{ 144 - 40{1'b0}}, xx_intc_vld[39:0]};
 assign pad_plic_int_vld[ 39 : 0] = xx_intc_vld[ 39 : 0];
 
-assign pad_plic_int_vld[144 - 1 : 32] = 'h0;
+assign pad_plic_int_vld[144 - 1 : 40] = 'h0;
 
 assign pad_plic_int_cfg  = 'b0;
 


### PR DESCRIPTION
Fix multiple drivers of `pad_plic_int_vld[39:32]`. These signals are currently driven here
https://github.com/T-head-Semi/openc910/blob/e0c4ad8ec7f8c70f649d826ebd6c949086453272/smart_run/logical/common/cpu_sub_system_axi.v#L365
and here
https://github.com/T-head-Semi/openc910/blob/e0c4ad8ec7f8c70f649d826ebd6c949086453272/smart_run/logical/common/cpu_sub_system_axi.v#L367